### PR TITLE
Version bump and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 **/ssh_key.pem
 **/*.tfstate
 **/*.tfstate.*
+**/.terraform.lock.hcl
+**/plan

--- a/aws/connections.tf
+++ b/aws/connections.tf
@@ -1,5 +1,3 @@
-
 provider "aws" {
-  version = "~> 2.54"
   region = var.aws_region
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,9 +1,10 @@
 output "host_ssh_key" {
   value = tls_private_key.ssh_key.private_key_pem
+  sensitive = true
 }
 
 output "grocy_host" {
-  value = aws_instance.grocy-ec2-instance.public_ip
+  value = aws_instance.grocy-ec2-instance.public_dns
 }
 
 output "grocy_url" {

--- a/aws/servers.tf
+++ b/aws/servers.tf
@@ -1,11 +1,9 @@
-provider "tls" {
-  version = "~> 2.1"
-}
+provider "tls" {}
+
 resource "tls_private_key" "ssh_key" {
   algorithm = "RSA"
   rsa_bits = 4096
 }
-
 
 resource "aws_key_pair" "generated_key" {
   key_name = var.ami_key_pair_name
@@ -59,7 +57,7 @@ resource "aws_instance" "grocy-ec2-instance" {
 
   // put in the correct domain name in .env
   provisioner "file" {
-    destination = "~/.env"
+    destination = "/home/ubuntu/.env"
     content = templatefile("${path.cwd}/../docker/.env.tpl", {
       grocy_domain_name =  "${var.grocy_duckdns_domain}.duckdns.org"
       bbuddy_domain_name =  "${var.grocy_bbuddy_duckdns_domain}.duckdns.org"
@@ -68,7 +66,7 @@ resource "aws_instance" "grocy-ec2-instance" {
 
   // put in the correct domain name in dns script
   provisioner "file" {
-    destination = "~/dns/register-duckdns.sh"
+    destination = "/home/ubuntu/dns/register-duckdns.sh"
     content = templatefile("${path.cwd}/../dns/register-duckdns.sh.tpl", {
       grocy_domain_name =  var.grocy_duckdns_domain
       bbuddy_domain_name =  var.grocy_bbuddy_duckdns_domain
@@ -78,7 +76,7 @@ resource "aws_instance" "grocy-ec2-instance" {
 
   // put in the correct domain name in dns script to wait for grocy server domain
   provisioner "file" {
-    destination = "~/dns/wait-for-dns.sh"
+    destination = "/home/ubuntu/dns/wait-for-dns.sh"
     content = templatefile("${path.cwd}/../dns/wait-for-dns.sh.tpl", {
       duckdns_domain =  var.grocy_duckdns_domain
       duckdns_token = var.duckdns_token
@@ -87,7 +85,7 @@ resource "aws_instance" "grocy-ec2-instance" {
 
   // put in the correct domain name in dns script to wait for bbuddy server domain
   provisioner "file" {
-    destination = "~/dns/wait-for-dns2.sh"
+    destination = "/home/ubuntu/dns/wait-for-dns2.sh"
     content = templatefile("${path.cwd}/../dns/wait-for-dns2.sh.tpl", {
       duckdns_domain =  var.grocy_bbuddy_duckdns_domain
       duckdns_token = var.duckdns_token
@@ -97,25 +95,25 @@ resource "aws_instance" "grocy-ec2-instance" {
   // Copy over dns scripts
   provisioner "file" {
     source = "${path.cwd}/../dns/"
-    destination = "~/dns"
+    destination = "/home/ubuntu/dns"
   }
 
   // Copy over docker scripts
   provisioner "file" {
     source = "${path.cwd}/../docker/"
-    destination = "~/"
+    destination = "/home/ubuntu/"
   }
 
   // Copy over letsencrypt-nginx-proxy-companion files
   provisioner "file" {
     source = "${path.cwd}/../docker-compose-letsencrypt-nginx-proxy-companion/"
-    destination = "~/docker-compose-letsencrypt-nginx-proxy-companion"
+    destination = "/home/ubuntu/docker-compose-letsencrypt-nginx-proxy-companion"
   }
 
   // Copy over backup scripts
   provisioner "file" {
     source = "${path.cwd}/../backup/"
-    destination = "~/"
+    destination = "/home/ubuntu/"
   }
 
   // Copy over Dropbox configs
@@ -126,7 +124,7 @@ resource "aws_instance" "grocy-ec2-instance" {
 
   provisioner "file" {
     source = "~/.config/dbxcli"
-    destination = "~/.config"
+    destination = "/home/ubuntu/.config"
   }
 
 

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.7"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = "~> 3.1"
+    }
+  }
+}

--- a/backup/grocy-backup.sh
+++ b/backup/grocy-backup.sh
@@ -5,9 +5,9 @@ wget -O ./dbxcli https://github.com/dropbox/dbxcli/releases/download/v3.0.0/dbxc
 sudo chmod a+x ./dbxcli
 if ./dbxcli account; then
   mkdir -p backup
-  sudo docker exec grocy apk add sqlite
-  sudo docker exec grocy sqlite3 /www/data/grocy.db ".backup 'backup_grocy.db'"
-  sudo docker cp grocy:/www/public/backup_grocy.db backup/grocy.db
+  sudo docker exec --user=root grocy apk add sqlite
+  sudo docker exec --user=root grocy sqlite3 /var/www/data/grocy.db ".backup 'backup_grocy.db'"
+  sudo docker cp grocy:/var/www/backup_grocy.db backup/grocy.db
   # Ignore any errors here since directory may have already been created
   set +e
   ./dbxcli mkdir grocy_backup

--- a/bin/ssh-host.sh
+++ b/bin/ssh-host.sh
@@ -8,4 +8,4 @@ terraform output host_ssh_key > $tmp_ssh_file
 
 chmod 400 $tmp_ssh_file
 
-ssh -i $tmp_ssh_file ubuntu@$(terraform output grocy_host)
+ssh -i $tmp_ssh_file ubuntu@$(terraform output --raw grocy_host)

--- a/docker-compose-letsencrypt-nginx-proxy-companion/start.sh
+++ b/docker-compose-letsencrypt-nginx-proxy-companion/start.sh
@@ -6,8 +6,8 @@
 #
 
 # 1. Check if .env file exists
-if [ -e .env ]; then
-    source .env
+if [ -e /home/ubuntu/.env ]; then
+    source /home/ubuntu/.env
 else 
     echo "It seems you didn´t create your .env file, so we will create one for you."
     cp .env.sample .env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,10 +5,10 @@ version: '2.4'
 services:
 
   nginx:
-    image: "grocy/nginx:v2.7.1-2"
+    image: "grocy/nginx:v3.0.1-12"
     build:
       args:
-        GROCY_VERSION: v2.7.1
+        GROCY_VERSION: v3.0.1
       context: .
       dockerfile: Dockerfile-grocy-nginx
     depends_on:
@@ -25,15 +25,15 @@ services:
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
       VIRTUAL_PORT: 8080
   grocy:
-    image: "grocy/grocy:v2.7.1-2"
+    image: "grocy/grocy:v3.0.1-12"
     build:
       args:
-        GROCY_VERSION: v2.7.1
+        GROCY_VERSION: v3.0.1
       context: .
       dockerfile: Dockerfile-grocy
     expose:
       - '9000'
-    read_only: true
+    read_only: false
     tmpfs:
       - /tmp
     volumes:


### PR DESCRIPTION
Hello, firstly I love this project - it was very helpful to get me up and running with grocy. It also gave me my first introduction to terraform!

The purpose of this branch it to update the version of `grocy` and `nginx` to the latest versions and then make any fixes related to that or the latest version of terraform.

Changes:

-  Added terraform lock file to `.gitignore`
- Added `plan` to `.gitignore` to prevent accidental commits
- Bumped the versions for `aws` and `tls`
- Moved the provider versions into `versions.tf` using the new syntax to comply with the most up to date terraform
- Made the `host_ssh_key` output variable sensitive
- Changed the `grocy_host` output variable to use the public dns instead of the public ip (inline with my understanding of best practice)
- Updated file paths in provisions to not use `~` as for some reason didn't work for me
- Added root user argument to docker exec in `grocy-backup.sh` - seems to be required in the latest `grocy` docker image
- Modified paths in `grocy-backup.sh` for new docker image
- Added `raw` argument in `ssh-host.sh` for the host output as most up to date version of terraform wraps the output in double quotes
- Used absolute path to the `.env` file in `start.sh`
- Bumped versions in `docker-compose.yml`
- Changed `readonly` to false in `docker-compose.yml` - this was required to use `apk add` in `grocy-backup.sh` I am unsure if this has any further implications that we should worry about.

